### PR TITLE
Use Mapping from collection.abc

### DIFF
--- a/examples/coaxial_stacking.py
+++ b/examples/coaxial_stacking.py
@@ -18,7 +18,10 @@ import math
 import sys
 import warnings
 from collections import defaultdict, namedtuple, OrderedDict#, Mapping
-from collections.abc import Mapping
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 import forgi.threedee.model.coarse_grain as ftmc
 #import forgi.threedee.utilities.dssr as ftud
 import forgi.threedee.utilities._dssr as ftud

--- a/forgi/threedee/model/_ensemble.py
+++ b/forgi/threedee/model/_ensemble.py
@@ -10,7 +10,10 @@ from builtins import (ascii, bytes, chr, dict, filter, hex, input,
                       str, super, zip, object)  # future package
 
 from collections import defaultdict, Sequence
-from collections.abc import Mapping
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 import itertools as it
 import numpy as np
 from sklearn.cluster import DBSCAN

--- a/forgi/threedee/model/_ensemble.py
+++ b/forgi/threedee/model/_ensemble.py
@@ -9,7 +9,8 @@ from builtins import (ascii, bytes, chr, dict, filter, hex, input,
                       int, map, next, oct, open, pow, range, round,
                       str, super, zip, object)  # future package
 
-from collections import Mapping, defaultdict, Sequence
+from collections import defaultdict, Sequence
+from collections.abc import Mapping
 import itertools as it
 import numpy as np
 from sklearn.cluster import DBSCAN

--- a/forgi/threedee/model/linecloud.py
+++ b/forgi/threedee/model/linecloud.py
@@ -9,7 +9,7 @@ else:
     viewkeys = lambda dic, **kwargs: dic.keys(**kwargs)
 
 import numpy as np
-from collections import Mapping
+from collections.abc import Mapping
 import itertools
 import logging
 import forgi.threedee.utilities.vector as ftuv

--- a/forgi/threedee/model/linecloud.py
+++ b/forgi/threedee/model/linecloud.py
@@ -9,7 +9,10 @@ else:
     viewkeys = lambda dic, **kwargs: dic.keys(**kwargs)
 
 import numpy as np
-from collections.abc import Mapping
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 import itertools
 import logging
 import forgi.threedee.utilities.vector as ftuv


### PR DESCRIPTION
In Python 3.10, collections remove the visibility of abc classes (Mapping included), making forgi throw an ImportError on import.
They were actually move to collections.abc since Python 3.3, so these changes should be retrocompatible with other Python 3 version.

If Python 2 is still supported, I can maybe wrapped it with `sys.version_info` condition ?