### PR TITLE
Show basepairs and enable choosing colors for basepairs when color variable is set to True

### DIFF
--- a/forgi/visual/mplotlib.py
+++ b/forgi/visual/mplotlib.py
@@ -291,9 +291,11 @@ def plot_rna(cg, ax=None, offset=(0, 0), text_kwargs={}, backbone_kwargs={},
             c = "red"
         else:
             c = "black"
-            bpkwargs = {"color":c, "zorder":0, "linewidth":3}
-            bpkwargs.update(basepair_kwargs)
-            ax.plot(basepairs[:,:,0].T, basepairs[:,:,1].T, **bpkwargs)
+            # Do not allow changing color through basepair_kwargs if color is set to False
+            basepair_kwargs["color"] = c
+        bpkwargs = {"color":c, "zorder":0, "linewidth":3}
+        bpkwargs.update(basepair_kwargs)
+        ax.plot(basepairs[:,:,0].T, basepairs[:,:,1].T, **bpkwargs)
     # Now plot circles
     for i, coord in enumerate(coords):
         if color:


### PR DESCRIPTION
I found that base-pairs connections are not shown neither can I change the color of connections. It seems that when color is set to True  variable "c" is set to "red" and that's it, while when color is set to False base-pairs connections are added to the plot.  This PR should fix that and base-pairs connections should be visible now when color is set to True, and additionally it should support changing the color for base-pairs connections.